### PR TITLE
HAI-1185: Change PETL pipeline jobs to support multiple facility locations in a single server

### DIFF
--- a/jobs/sql/extractions/all_encounters.sql
+++ b/jobs/sql/extractions/all_encounters.sql
@@ -15,6 +15,7 @@ create temporary table temp_all_encounters
     user_entered         varchar(255),
     location_id          int(11),
     encounter_location   varchar(255),
+    facility             varchar(255),
     visit_location_id    int(11),
     visit_location       varchar(255),
     encounter_type_id    int(11),
@@ -88,8 +89,9 @@ set t.encounter_type_name = et.encounter_type_name;
 drop temporary table if exists locations;
 create temporary table locations
 (
-	location_id  int(11),
-	location_name varchar(511)
+	location_id   int(11),
+	location_name varchar(511),
+	facility      varchar(255)
 );
 
 insert into locations(location_id)
@@ -104,10 +106,14 @@ update locations ls
 inner join location l on l.location_id = ls.location_id
 set ls.location_name = name;
 
+update locations ls
+set ls.facility = location_tag_ancestor(ls.location_id, 'Visit Location');
+
 create index temp_all_encounters_li on temp_all_encounters(location_id);
 update temp_all_encounters t
 inner join locations ls on ls.location_id = t.location_id
-set t.encounter_location = ls.location_name;
+set t.encounter_location = ls.location_name,
+    t.facility = ls.facility;
 
 create index temp_all_encounters_vli on temp_all_encounters(visit_location_id);
 update temp_all_encounters t
@@ -199,6 +205,7 @@ select emr_id,
        visit_location,
        encounter_type_name,
        encounter_location,
+       facility,
        encounter_datetime,
        entered_datetime,
        user_entered,

--- a/jobs/sql/extractions/all_encounters.sql
+++ b/jobs/sql/extractions/all_encounters.sql
@@ -15,6 +15,8 @@ create temporary table temp_all_encounters
     user_entered         varchar(255),
     location_id          int(11),
     encounter_location   varchar(255),
+    visit_location_id    int(11),
+    visit_location       varchar(255),
     encounter_type_id    int(11),
     encounter_type_name  varchar(50),
     entered_datetime     datetime,
@@ -48,12 +50,14 @@ create index temp_all_encounters_encounterId ON temp_all_encounters (encounter_i
 -- Load the encounters
 update temp_all_encounters t
 inner join encounter e on t.encounter_id = e.encounter_id
+left join visit v on v.visit_id = e.visit_id
 set t.encounter_datetime = e.encounter_datetime,
-    t.encounter_type_id = e.encounter_type, 
-    t.location_id = e.location_id, 
+    t.encounter_type_id = e.encounter_type,
+    t.location_id = e.location_id,
     t.patient_id = e.patient_id,
     t.visit_id = e.visit_id,
-    t.creator = e.creator, 
+    t.visit_location_id = v.location_id,
+    t.creator = e.creator,
     t.entered_datetime = e.date_created,
     t.voided = e.voided
 ;
@@ -91,6 +95,9 @@ create temporary table locations
 insert into locations(location_id)
 select distinct location_id from temp_all_encounters;
 
+insert into locations(location_id)
+select distinct visit_location_id from temp_all_encounters where visit_location_id is not null;
+
 create index locations_li on locations(location_id);
 
 update locations ls
@@ -101,6 +108,11 @@ create index temp_all_encounters_li on temp_all_encounters(location_id);
 update temp_all_encounters t
 inner join locations ls on ls.location_id = t.location_id
 set t.encounter_location = ls.location_name;
+
+create index temp_all_encounters_vli on temp_all_encounters(visit_location_id);
+update temp_all_encounters t
+inner join locations ls on ls.location_id = t.visit_location_id
+set t.visit_location = ls.location_name;
 
 -- update user entered
 drop temporary table if exists user_names;
@@ -184,6 +196,7 @@ select emr_id,
        CONCAT(@partition, '-', encounter_id) as encounter_id,
        CONCAT(@partition, '-', patient_id) as patient_id,
        CONCAT(@partition, '-', visit_id) as visit_id,
+       visit_location,
        encounter_type_name,
        encounter_location,
        encounter_datetime,

--- a/jobs/sql/extractions/all_encounters.sql
+++ b/jobs/sql/extractions/all_encounters.sql
@@ -16,8 +16,6 @@ create temporary table temp_all_encounters
     location_id          int(11),
     encounter_location   varchar(255),
     facility             varchar(255),
-    visit_location_id    int(11),
-    visit_location       varchar(255),
     encounter_type_id    int(11),
     encounter_type_name  varchar(50),
     entered_datetime     datetime,
@@ -51,13 +49,11 @@ create index temp_all_encounters_encounterId ON temp_all_encounters (encounter_i
 -- Load the encounters
 update temp_all_encounters t
 inner join encounter e on t.encounter_id = e.encounter_id
-left join visit v on v.visit_id = e.visit_id
 set t.encounter_datetime = e.encounter_datetime,
     t.encounter_type_id = e.encounter_type,
     t.location_id = e.location_id,
     t.patient_id = e.patient_id,
     t.visit_id = e.visit_id,
-    t.visit_location_id = v.location_id,
     t.creator = e.creator,
     t.entered_datetime = e.date_created,
     t.voided = e.voided
@@ -94,17 +90,10 @@ create temporary table locations
 	facility      varchar(255)
 );
 
-insert into locations(location_id)
-select distinct location_id from temp_all_encounters;
-
-insert into locations(location_id)
-select distinct visit_location_id from temp_all_encounters where visit_location_id is not null;
+insert into locations(location_id, location_name)
+select location_id, name from location;
 
 create index locations_li on locations(location_id);
-
-update locations ls
-inner join location l on l.location_id = ls.location_id
-set ls.location_name = name;
 
 update locations ls
 set ls.facility = location_tag_ancestor(ls.location_id, 'Visit Location');
@@ -114,11 +103,6 @@ update temp_all_encounters t
 inner join locations ls on ls.location_id = t.location_id
 set t.encounter_location = ls.location_name,
     t.facility = ls.facility;
-
-create index temp_all_encounters_vli on temp_all_encounters(visit_location_id);
-update temp_all_encounters t
-inner join locations ls on ls.location_id = t.visit_location_id
-set t.visit_location = ls.location_name;
 
 -- update user entered
 drop temporary table if exists user_names;
@@ -202,7 +186,6 @@ select emr_id,
        CONCAT(@partition, '-', encounter_id) as encounter_id,
        CONCAT(@partition, '-', patient_id) as patient_id,
        CONCAT(@partition, '-', visit_id) as visit_id,
-       visit_location,
        encounter_type_name,
        encounter_location,
        facility,

--- a/jobs/sql/schemas/all_encounters.sql
+++ b/jobs/sql/schemas/all_encounters.sql
@@ -4,7 +4,6 @@ create table all_encounters
     encounter_id        varchar(25),
     patient_id          varchar(25),
     visit_id            varchar(25),
-    visit_location      varchar(255),
     encounter_type_name varchar(50),
     encounter_location  varchar(255),
     facility            varchar(255),

--- a/jobs/sql/schemas/all_encounters.sql
+++ b/jobs/sql/schemas/all_encounters.sql
@@ -7,6 +7,7 @@ create table all_encounters
     visit_location      varchar(255),
     encounter_type_name varchar(50),
     encounter_location  varchar(255),
+    facility            varchar(255),
     encounter_datetime  datetime,
     entered_datetime    datetime,
     user_entered        varchar(255),

--- a/jobs/sql/schemas/all_encounters.sql
+++ b/jobs/sql/schemas/all_encounters.sql
@@ -4,6 +4,7 @@ create table all_encounters
     encounter_id        varchar(25),
     patient_id          varchar(25),
     visit_id            varchar(25),
+    visit_location      varchar(255),
     encounter_type_name varchar(50),
     encounter_location  varchar(255),
     encounter_datetime  datetime,

--- a/jobs/sql/utils/create_functions.sql
+++ b/jobs/sql/utils/create_functions.sql
@@ -918,6 +918,44 @@ BEGIN
 END
 #
 /*
+  location_tag_ancestor
+  Walks up the location parent hierarchy from loc_id and returns the name of the
+  first ancestor (inclusive) that carries the given location tag. Returns NULL if
+  no tagged ancestor is found.
+*/
+#
+DROP FUNCTION IF EXISTS location_tag_ancestor;
+#
+CREATE FUNCTION location_tag_ancestor(loc_id INT, tag_name VARCHAR(255))
+    RETURNS VARCHAR(255)
+    DETERMINISTIC
+BEGIN
+    DECLARE current_id INT DEFAULT loc_id;
+    DECLARE loc_name   VARCHAR(255) DEFAULT NULL;
+    DECLARE parent_id  INT DEFAULT NULL;
+    DECLARE has_tag    TINYINT DEFAULT 0;
+
+    WHILE current_id IS NOT NULL DO
+        SELECT l.name, l.parent_location,
+               EXISTS(
+                   SELECT 1 FROM location_tag_map ltm
+                   INNER JOIN location_tag lt ON lt.location_tag_id = ltm.location_tag_id
+                   WHERE ltm.location_id = current_id AND lt.name = tag_name
+               )
+        INTO loc_name, parent_id, has_tag
+        FROM location l WHERE l.location_id = current_id;
+
+        IF has_tag THEN
+            RETURN loc_name;
+        END IF;
+
+        SET current_id = parent_id;
+    END WHILE;
+
+    RETURN NULL;
+END
+#
+/*
 Encounter Date
 */
 #


### PR DESCRIPTION

So @dmdesimone and @mseaton a preliminary PR for you to review, this added two similar but slightly different fields to the all_encounters table:

* visit_location - text name of the location associated with the visit, if any, associated with the encounter
* facility - nearest ancestor up the the location hierarchy from the "encounter_location" that is tagged as a "Visit Location"

The reason why there are two is simply because I asked Claude to do visit location first and then realized we needed something for encounter types (like registration encounters) that happen outside of a visit. We could go back and remove the the visit_location but it seems like it doesn't hurt to add it?

Quick screenshot of a few rows after running the pipeline against one of my dev databases:

<img width="1711" height="315" alt="image" src="https://github.com/user-attachments/assets/b866598d-5e09-41ec-b902-b04adc9495d8" />

Hopefully if "site" is beginning used in any downstream exports we can update it to use "Facility" instead?

I asked Claude to go ahead and add "visit_location" to all exports that have a "visit_id" column, and "facility" to all exports that have an "encounter_location".... it's finished but I haven't tested yet, and I thought this smaller PR would be easier to review to start.

